### PR TITLE
Switch to new Bun plugin repository with dynamic version fetching

### DIFF
--- a/sources/bun.json
+++ b/sources/bun.json
@@ -1,6 +1,6 @@
 {
   "name": "bun",
-  "manifestUrl": "https://github.com/ahai-code/vfox-bun/releases/download/manifest/manifest.json",
+  "manifestUrl": "https://github.com/arfaWong/vfox-bun/releases/download/manifest/manifest.json",
   "test": {
     "version": "1.1.1",
     "check": " bun --version",


### PR DESCRIPTION
This PR proposes an update to the `vfox bun` plugin by changing its source repository.

The current Bun plugin for vfox has a couple of limitations:
1.  It hardcodes Bun versions directly within the plugin's code.
2.  It hasn't received updates in approximately 11 months, meaning newer Bun versions are not available through it without manual plugin modification.
https://github.com/ahai-code/vfox-bun/issues/4
https://github.com/ahai-code/vfox-bun/pull/5

This PR updates the plugin source to point to a new Bun plugin repository:
https://github.com/arfaWong/vfox-bun

Please review this change. I believe this will significantly improve the user experience for `vfox bun` users.