### PR TITLE
Add Rust Plugin to Registry

### DIFF
--- a/plugins/rust.json
+++ b/plugins/rust.json
@@ -1,0 +1,12 @@
+{
+  "manifestUrl": "https://github.com/XZzYassin/vfox-rust/releases/download/manifest/manifest.json",
+  "notes": [],
+  "description": "Rust plugin https://releases.rs/docs/",
+  "downloadUrl": "https://github.com/XZzYassin/vfox-rust/releases/download/v1.0.0/vfox-rust-1.0.0.zip",
+  "minRuntimeVersion": "0.3.0",
+  "name": "rust",
+  "homepage": "https://github.com/XZzYassin/vfox-rust",
+  "license": "Apache 2.0",
+  "legacyFilenames": [],
+  "version": "1.0.0"
+}

--- a/sources/rust.json
+++ b/sources/rust.json
@@ -1,0 +1,9 @@
+{
+  "name": "rust",
+  "manifestUrl": "https://github.com/xzzyassin/vfox-rust/releases/download/manifest/manifest.json",
+  "test": {
+    "version": "1.90.0",
+    "check": "rustc --version",
+    "resultRegx": "rustc (\\d+\\.\\d+\\.\\d+) \\(\\w+ \\d{4}-\\d{2}-\\d{2}\\)"
+  }
+}


### PR DESCRIPTION
This pull request adds support for the Rust programming language by introducing new plugin and source configuration files. These files define how the Rust plugin is downloaded, described, and tested within the system.

**Rust plugin integration:**

* Added a new plugin configuration file `plugins/rust.json` specifying metadata, download URLs, version, and compatibility information for the Rust plugin.

**Rust source definition:**

* Added a new source definition file `sources/rust.json` that describes how to test the Rust installation by checking the version using `rustc --version` and a regular expression to validate the result.

Resolves: #16 