### PR TITLE
Add mongod Plugin to Registry

### DIFF
--- a/plugins/mongod.json
+++ b/plugins/mongod.json
@@ -1,0 +1,12 @@
+{
+  "manifestUrl": "https://raw.githubusercontent.com/echocat/vfox-mongod/refs/heads/main/manifest.json",
+  "notes": [],
+  "description": "A mise tool plugin for mongod",
+  "downloadUrl": "https://github.com/echocat/vfox-mongod/releases/download/v1.2.2/vfox-mongod-1.2.2.zip",
+  "minRuntimeVersion": "0.5.0",
+  "name": "mongod",
+  "homepage": "https://github.com/echocat/vfox-mongod",
+  "license": "MIT",
+  "legacyFilenames": [],
+  "version": "1.2.2"
+}

--- a/sources/mongod.json
+++ b/sources/mongod.json
@@ -1,0 +1,9 @@
+{
+  "name": "mongo",
+  "manifestUrl": "https://raw.githubusercontent.com/echocat/vfox-mongod/refs/heads/main/manifest.json",
+  "test": {
+    "version": "8.2.1",
+    "check": "mongod --version",
+    "resultRegx": "db version: v(\\d+\\.\\d+)"
+  }
+}


### PR DESCRIPTION
This pull request adds **another** version of mongod which works on more platforms and can use regular versioning because it resolved the dependencies based on the current host (on linux it parses also `/etc/os-release` to find the matching release). Therefore, you can simply use `vfox install mongod@8.2.1` instead of `vfox install <other_plugin>@x86_64-ubuntu2004-8.2.1`.

Added a new plugin configuration file plugins/mongod.json specifying metadata, download URLs, version, and compatibility information for the mongod plugin.

Added a new source definition file sources/mongod.json that describes how to test the Rust installation by checking the version using mongod --version and a regular expression to validate the result.
