### PR TITLE
Add grails plugin

### DIFF
--- a/sources/grails.json
+++ b/sources/grails.json
@@ -1,0 +1,9 @@
+{
+  "name": "grails",
+  "manifestUrl": "https://github.com/verglor/vfox-grails/releases/download/manifest/manifest.json",
+  "test": {
+    "version": "6.2.0",
+    "check": "grails --version",
+    "resultRegx": "Grails Version:\\s+(\\d+\\.\\d+\\.\\d+)"
+  }
+}


### PR DESCRIPTION
## Summary

- Adds `sources/grails.json` to register the [vfox-grails](https://github.com/verglor/vfox-grails) plugin
- Plugin manages Grails SDK versions and sets `GRAILS_HOME` / `PATH` accordingly
- Apache 2.0 licensed

## Test plan

- [ ] CI fetches manifest from `https://github.com/verglor/vfox-grails/releases/download/manifest/manifest.json`
- [ ] `plugins/grails.json` is auto-generated correctly after merge
- [ ] `index.json` is updated to include the grails entry